### PR TITLE
Enable targeting .NET Standard 2.0

### DIFF
--- a/Dogged/Dogged.csproj
+++ b/Dogged/Dogged.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -20,5 +20,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Dogged.Native\Dogged.Native.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Enable targeting .NET Standard 2.0 as well as .NET Standard 2.1 to allow consumers on .NET Framework and downlevel .NET Core 2.0 runtimes to consume Dogged.

When the Target Framework is netstandard2.0 we pull in the System.Memory package which includes the `Span<T>` and `Memory<T>` types that are used in the library but missing from the standard < v2.1.