### PR TITLE
Commit: Support parent commits and message

### DIFF
--- a/Dogged.Native/libgit2.cs
+++ b/Dogged.Native/libgit2.cs
@@ -148,6 +148,33 @@ namespace Dogged.Native
         public static extern unsafe int git_commit_lookup(out git_commit* obj, git_repository* repo, ref git_oid id);
 
         /// <summary>
+        /// Get the message of the commit.
+        /// </summary>
+        /// <param name="commit">The commit to examine</param>
+        /// <returns>The commit message string.</returns>
+        [DllImport(libgit2_dll, CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = Utf8Marshaler.FromNative, MarshalTypeRef = typeof(Utf8Marshaler))]
+        public static extern unsafe string git_commit_message(git_commit* commit);
+
+        /// <summary>
+        /// Get the number of parents for the commit.
+        /// </summary>
+        /// <param name="commit">The commit to examine</param>
+        /// <returns>The number of parent commits.</returns>
+        [DllImport(libgit2_dll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe UIntPtr git_commit_parentcount(git_commit* commit);
+
+        /// <summary>
+        /// Get the specified parent for the commit.
+        /// </summary>
+        /// <param name="parent">Pointer to the parent commit</param>
+        /// <param name="commit">The commit to examine</param>
+        /// <param name="n">The position of the parent commit</param>
+        /// <returns>0 on success or an error code</returns>
+        [DllImport(libgit2_dll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int git_commit_parent(out git_commit* parent, git_commit* commit, UIntPtr n);
+
+        /// <summary>
         /// Get the tree that the given commit points to.  This tree must be
         /// freed when it is no longer needed.
         /// </summary>

--- a/Dogged.Tests/CommitTests.cs
+++ b/Dogged.Tests/CommitTests.cs
@@ -25,6 +25,11 @@ namespace Dogged.Tests
                 Assert.Equal("Scott Chacon", c.Author.Name);
                 Assert.Equal("schacon@gmail.com", c.Author.Email);
                 Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1274813907), c.Author.When);
+                Assert.Equal("Merge branch 'br2'\n", c.Message);
+
+                Assert.Equal(2, c.Parents.Count);
+                Assert.Equal(new ObjectId("9fd738e8f7967c078dceed8190330fc8648ee56a"), c.Parents[0].Id);
+                Assert.Equal(new ObjectId("c47800c7266a2be04c571c04d5a6614691ea99bd"), c.Parents[1].Id);
 
                 Assert.Equal(new ObjectId("1810dff58d8a660512d4832e740f692884338ccd"), c.TreeId);
             }

--- a/Dogged/Commit.cs
+++ b/Dogged/Commit.cs
@@ -11,6 +11,7 @@ namespace Dogged
         private LazyNative<Signature> author;
         private LazyNative<Signature> committer;
         private readonly LazyNative<ObjectId> treeId;
+        private readonly Lazy<CommitParentCollection> parents;
 
         private unsafe Commit(git_commit* nativeCommit, ObjectId id) :
             base((git_object*)nativeCommit, id)
@@ -28,6 +29,7 @@ namespace Dogged
                 Ensure.NativePointerNotNull(oid);
                 return ObjectId.FromNative(*oid);
             }, this);
+            parents = new Lazy<CommitParentCollection>(() => new CommitParentCollection(this));
         }
 
         internal unsafe static Commit FromNative(git_commit* nativeCommit, ObjectId id = null)
@@ -35,7 +37,7 @@ namespace Dogged
             return new Commit(nativeCommit, id);
         }
 
-        private unsafe git_commit* NativeCommit
+        internal unsafe git_commit* NativeCommit
         {
             get
             {
@@ -98,6 +100,28 @@ namespace Dogged
                 Ensure.NativePointerNotNull(tree);
 
                 return Tree.FromNative(tree);
+            }
+        }
+
+        /// <summary>
+        /// Gets the message for this commit.
+        /// </summary>
+        public unsafe string Message
+        {
+            get
+            {
+                return libgit2.git_commit_message(NativeCommit);
+            }
+        }
+
+        /// <summary>
+        /// An accessor for parent commits.
+        /// </summary>
+        public CommitParentCollection Parents
+        {
+            get
+            {
+                return parents.Value;
             }
         }
     }

--- a/Dogged/CommitParentCollection.cs
+++ b/Dogged/CommitParentCollection.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Dogged.Native;
+
+namespace Dogged
+{
+    /// <summary>
+    /// Accessors for the Git parents (commits) of a commit.
+    /// </summary>
+    public class CommitParentCollection
+    {
+        private Commit commit;
+        private readonly LazyNative<int> count;
+
+        internal unsafe CommitParentCollection(Commit commit)
+        {
+            this.commit = commit;
+            count = new LazyNative<int>(() => {
+                UIntPtr count = Ensure.NativeCall<UIntPtr>(() => libgit2.git_commit_parentcount(commit.NativeCommit), this.commit);
+                return Ensure.CastToInt(count, "count");
+            }, this.commit);
+        }
+
+        /// <summary>
+        /// Gets the number of parent commits.
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                return count.Value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the parent commit at the specified index.
+        /// </summary>
+        public unsafe Commit this[int position]
+        {
+            get
+            {
+                Ensure.NotDisposed(commit.NativeObject, "commit");
+                Ensure.ArgumentConformsTo(() => position >= 0, "position", "position must not be negative");
+
+                git_commit* parent = null;
+                Ensure.NativeSuccess(() => libgit2.git_commit_parent(out parent, commit.NativeCommit, (UIntPtr)position), this.commit);
+                Ensure.NativePointerNotNull(parent);
+
+                return Commit.FromNative(parent);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added support for reading the commit message, and traversing parent commits.