### PR TITLE
PathSpec: add simple tree matching

### DIFF
--- a/Dogged.Native/Internal/StrArrayMarshaler.cs
+++ b/Dogged.Native/Internal/StrArrayMarshaler.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+using Dogged.Native.Services;
+
+namespace Dogged.Native
+{
+    /// <summary>
+    /// A custom marshaler suitable for marshaling git_strarray to/from string[]
+    /// for use in libgit2.
+    /// </summary>
+    internal class StrArrayMarshaler : ICustomMarshaler
+    {
+        /// <summary>
+        /// The "ToNative" cookie will provide an instance of the marshaler
+        /// for use converting managed string[] to native git_strarray.
+        /// When used as the CustomMarshaler for a PInvoke context, this
+        /// marshaler will free the native memory after the native function
+        /// returns.
+        /// </summary>
+        public const string ToNative = "ToNative";
+
+        /// <summary>
+        /// The "FromNative" cookie will provide an instance of the marshaler
+        /// for use converting git_strarray to managed string[].
+        /// When used as the CustomMarshaler for a PInvoke context, this
+        /// marshaler will not free the native memory after the native
+        /// function results, since the native string is owned by the
+        /// library itself.
+        /// </summary>
+        public const string FromNative = "FromNative";
+
+        private static readonly StrArrayMarshaler fromNativeInstance = new StrArrayMarshaler(false);
+        private static readonly StrArrayMarshaler toNativeInstance = new StrArrayMarshaler(true);
+
+        private readonly bool cleanup;
+
+        public static ICustomMarshaler GetInstance(string cookie)
+        {
+            switch (cookie)
+            {
+                case ToNative:
+                    return toNativeInstance;
+                case FromNative:
+                    return fromNativeInstance;
+                default:
+                    throw new ArgumentException("invalid encoding cookie");
+            }
+        }
+
+        private StrArrayMarshaler(bool cleanup)
+        {
+            this.cleanup = cleanup;
+        }
+
+        public int GetNativeDataSize()
+        {
+            return -1;
+        }
+
+        public unsafe IntPtr MarshalManagedToNative(Object value)
+        {
+            if (value == null)
+            {
+                return IntPtr.Zero;
+            }
+
+            var managedStrArray = value as string[];
+            if (managedStrArray == null)
+            {
+                throw new MarshalDirectiveException("Cannot marshal a non-string[]");
+            }
+
+            var nativeStrArray = (git_strarray*)Marshal.AllocHGlobal(sizeof(git_strarray)).ToPointer();
+            nativeStrArray->strings = null;
+            nativeStrArray->count = new UIntPtr((uint)managedStrArray.Length);
+            
+            if (managedStrArray.Length > 0)
+            {
+                nativeStrArray->strings = (IntPtr*)Marshal.AllocHGlobal(sizeof(IntPtr) * managedStrArray.Length).ToPointer();
+                for (var i = 0; i < managedStrArray.Length; i++)
+                {
+                    nativeStrArray->strings[i] = Utf8Converter.ToNative(managedStrArray[i]);
+                }
+            }
+
+            return new IntPtr(nativeStrArray);
+        }
+
+        public unsafe object MarshalNativeToManaged(IntPtr ptr)
+        {
+            if (ptr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var nativeStrArray = (git_strarray*)ptr.ToPointer();
+            var managedStrArray = new string[nativeStrArray->count.ToUInt32()];
+
+            for (var i = 0; i < managedStrArray.Length; i++)
+            {
+                managedStrArray[i] = Utf8Converter.FromNative((byte*)nativeStrArray->strings[i]);
+            }
+
+            return managedStrArray;
+        }
+
+        public void CleanUpManagedData(object value)
+        {
+        }
+
+        public unsafe virtual void CleanUpNativeData(IntPtr ptr)
+        {
+            if (ptr != IntPtr.Zero && cleanup)
+            {
+                var nativeStrArray = (git_strarray*)ptr.ToPointer();
+
+                var count = nativeStrArray->count.ToUInt32();
+                for (var i = 0; i < count; i++)
+                {
+                    Marshal.FreeHGlobal(nativeStrArray->strings[i]);
+                }
+
+                Marshal.FreeHGlobal(new IntPtr(nativeStrArray->strings));
+                Marshal.FreeHGlobal(ptr);
+            }
+        }
+    }
+}

--- a/Dogged.Native/libgit2.cs
+++ b/Dogged.Native/libgit2.cs
@@ -700,6 +700,45 @@ namespace Dogged.Native
 
         #endregion
 
+        // pathspec
+        #region git_pathspec
+
+        /// <summary>
+        /// Creates a new pathspec.
+        /// </summary>
+        /// <param name="pathspec">Pointer to the new pathspec.</param>
+        /// <param name="paths">The paths to match.</param>
+        /// <returns>0 on success or an error code.</returns>
+        [DllImport(libgit2_dll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int git_pathspec_new(
+            out git_pathspec* pathspec,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = StrArrayMarshaler.ToNative, MarshalTypeRef = typeof(StrArrayMarshaler))] string[] paths);
+
+        /// <summary>
+        /// Free a pathspec.
+        /// </summary>
+        /// <param name="pathspec">The pathspec object.</param>
+        [DllImport(libgit2_dll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe void git_pathspec_free(
+            git_pathspec* pathspec);
+
+        /// <summary>
+        /// Match a pathspec against files in a tree.
+        /// </summary>
+        /// <param name="matchList">Pointer to list of matches.</param>
+        /// <param name="tree">The root-level tree to match against.</param>
+        /// <param name="flags">Options to control the match.</param>
+        /// <param name="pathspec">The pathspec to match.</param>
+        /// <returns>0 on success, -1 on error, GIT_ENOTFOUND if no matches and the GIT_PATHSPEC_NO_MATCH_ERROR flag is used.</returns>
+        [DllImport(libgit2_dll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int git_pathspec_match_tree(
+            ref git_pathspec_match_list* matchList,
+            git_tree* tree,
+            git_pathspec_flag_t flags,
+            git_pathspec* pathspec);
+
+        #endregion
+
         // repository
         #region git_repository
 

--- a/Dogged.Native/pathspec.cs
+++ b/Dogged.Native/pathspec.cs
@@ -1,0 +1,61 @@
+﻿namespace Dogged.Native
+{
+    /// <summary>
+    /// Options controlling how pathspec match should be executed.
+    /// </summary>
+    public enum git_pathspec_flag_t
+    {
+        GIT_PATHSPEC_DEFAULT = 0,
+
+        /// <summary>
+        /// GIT_PATHSPEC_IGNORE_CASE forces match to ignore case; otherwise
+        /// match will use native case sensitivity of platform filesystem
+        /// </summary>
+        GIT_PATHSPEC_IGNORE_CASE = (1 << 0),
+
+        /// <summary>
+        /// GIT_PATHSPEC_USE_CASE forces case sensitive match; otherwise
+        /// match will use native case sensitivity of platform filesystem
+        /// </summary>
+        GIT_PATHSPEC_USE_CASE = (1 << 1),
+
+        /// <summary>
+        /// GIT_PATHSPEC_NO_GLOB disables glob patterns and just uses simple
+	    /// string comparison for matching
+        /// </summary>
+        GIT_PATHSPEC_NO_GLOB = (1 << 2),
+
+        /// <summary>
+        /// GIT_PATHSPEC_NO_MATCH_ERROR means the match functions return error
+        /// code GIT_ENOTFOUND if no matches are found; otherwise no matches is
+        /// still success (return 0) but `git_pathspec_match_list_entrycount`
+        /// will indicate 0 matches.
+        /// </summary>
+        GIT_PATHSPEC_NO_MATCH_ERROR = (1 << 3),
+
+        /// <summary>
+        /// GIT_PATHSPEC_FIND_FAILURES means that the `git_pathspec_match_list`
+        /// should track which patterns matched which files so that at the end of
+        /// the match we can identify patterns that did not match any files.
+        /// </summary>
+        GIT_PATHSPEC_FIND_FAILURES = (1 << 4),
+
+        /// <summary>
+        /// GIT_PATHSPEC_FAILURES_ONLY means that the `git_pathspec_match_list`
+        /// does not need to keep the actual matching filenames.  Use this to
+        /// just test if there were any matches at all or in combination with
+        /// GIT_PATHSPEC_FIND_FAILURES to validate a pathspec.
+        /// </summary>
+        GIT_PATHSPEC_FAILURES_ONLY = (1 << 5),
+    }
+
+    /// <summary>
+    /// Representation of a pathspec.
+    /// </summary>
+    public struct git_pathspec { }
+
+    /// <summary>
+    /// Representation of a pathspec match list.
+    /// </summary>
+    public struct git_pathspec_match_list { }
+}

--- a/Dogged.Native/strarray.cs
+++ b/Dogged.Native/strarray.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Dogged.Native
+{
+    /// <summary>
+    /// Representation of string array.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct git_strarray
+    {
+        public unsafe IntPtr* strings;
+        public UIntPtr count;
+    }
+}

--- a/Dogged.Tests/PathSpecTests.cs
+++ b/Dogged.Tests/PathSpecTests.cs
@@ -1,0 +1,59 @@
+﻿using Xunit;
+
+namespace Dogged.Tests
+{
+    /// <summary>
+    /// Tests for pathspec.
+    /// </summary>
+    public class PathSpecTests : TestBase
+    {
+        [Fact]
+        public void CanMatchTreeExistingFile()
+        {
+            string repositoryPath = SandboxResource("testrepo");
+
+            using (Repository repo = Repository.Open(repositoryPath))
+            {
+                Assert.True(repo.HeadCommit.Tree.IsMatch(PathSpec.Create("branch_file.txt")));
+                Assert.True(repo.HeadCommit.Tree.IsMatch(PathSpec.Create("BRANCH_FILE.TXT"), PathSpecFlags.IgnoreCase));
+                Assert.False(repo.HeadCommit.Tree.IsMatch(PathSpec.Create("BRANCH_FILE.TXT"), PathSpecFlags.UseCase));
+            }
+        }
+
+        [Fact]
+        public void CanMatchTreeNonExistentFile()
+        {
+            string repositoryPath = SandboxResource("testrepo");
+
+            using (Repository repo = Repository.Open(repositoryPath))
+            {
+                Assert.False(repo.HeadCommit.Tree.IsMatch(PathSpec.Create("nothing.txt")));
+                Assert.False(repo.HeadCommit.Tree.IsMatch(PathSpec.Create("NOTHING.TXT"), PathSpecFlags.IgnoreCase));
+                Assert.False(repo.HeadCommit.Tree.IsMatch(PathSpec.Create("NOTHING.TXT"), PathSpecFlags.UseCase));
+            }
+        }
+
+        [Fact]
+        public void CanMatchTreeAnyFile()
+        {
+            string repositoryPath = SandboxResource("testrepo");
+
+            using (Repository repo = Repository.Open(repositoryPath))
+            {
+                Assert.True(repo.HeadCommit.Tree.IsMatch(PathSpec.Create("branch_file.txt", "nothing.txt")));
+            }
+        }
+
+        [Fact]
+        public void CanMatchTreeGlobbing()
+        {
+            string repositoryPath = SandboxResource("testrepo");
+
+            using (Repository repo = Repository.Open(repositoryPath))
+            {
+                Assert.True(repo.HeadCommit.Tree.IsMatch(PathSpec.Create("branch_file.*")));
+                Assert.False(repo.HeadCommit.Tree.IsMatch(PathSpec.Create("branch_file.*"), PathSpecFlags.NoGlob));
+            }
+        }
+    }
+}

--- a/Dogged/PathSpec.cs
+++ b/Dogged/PathSpec.cs
@@ -1,0 +1,93 @@
+﻿using Dogged.Native;
+
+namespace Dogged
+{
+    public enum PathSpecFlags
+    {
+        Default = git_pathspec_flag_t.GIT_PATHSPEC_DEFAULT,
+
+        /// <summary>
+        /// Forces match to ignore case; otherwise match will use native case sensitivity of platform filesystem.
+        /// </summary>
+        IgnoreCase = git_pathspec_flag_t.GIT_PATHSPEC_IGNORE_CASE,
+
+        /// <summary>
+        /// Forces case sensitive match; otherwise match will use native case sensitivity of platform filesystem.
+        /// </summary>
+        UseCase = git_pathspec_flag_t.GIT_PATHSPEC_USE_CASE,
+
+        /// <summary>
+        /// Disables glob patterns and just uses simple string comparison for matching.
+        /// </summary>
+        NoGlob = git_pathspec_flag_t.GIT_PATHSPEC_NO_GLOB,
+
+        /// <summary>
+        /// Means the match functions return error code GIT_ENOTFOUND if no matches are found;
+        /// otherwise no matches is still success (return 0) but `git_pathspec_match_list_entrycount`
+        /// will indicate 0 matches.
+        /// </summary>
+        NoMatchError = git_pathspec_flag_t.GIT_PATHSPEC_NO_MATCH_ERROR,
+
+        /// <summary>
+        /// Indicates that the `git_pathspec_match_list` should track which patterns matched
+        /// which files so that at the end of the match we can identify patterns that did not
+        /// match any files.
+        /// </summary>
+        FindFailures = git_pathspec_flag_t.GIT_PATHSPEC_FIND_FAILURES,
+
+        /// <summary>
+        /// Indicates that the `git_pathspec_match_list` does not need to keep the actual
+        /// matching filenames. Use this to just test if there were any matches at all or
+        /// in combination with GIT_PATHSPEC_FIND_FAILURES to validate a pathspec.
+        /// </summary>
+        FailuresOnly = git_pathspec_flag_t.GIT_PATHSPEC_FAILURES_ONLY,
+    }
+
+    /// <summary>
+    /// Representation of a pathspec.
+    /// </summary>
+    public unsafe class PathSpec : NativeDisposable
+    {
+        private git_pathspec* nativePathspec;
+
+        private PathSpec(git_pathspec* nativePathspec)
+        {
+            Ensure.NativePointerNotNull(nativePathspec);
+            this.nativePathspec = nativePathspec;
+        }
+
+        public unsafe static PathSpec Create(params string[] paths)
+        {
+            Ensure.ArgumentNotNull(paths, "paths");
+
+            git_pathspec* nativePathspec;
+            Ensure.NativeSuccess(libgit2.git_pathspec_new(out nativePathspec, paths));
+            return new PathSpec(nativePathspec);
+        }
+
+        internal git_pathspec* NativePathspec
+        {
+            get
+            {
+                return nativePathspec;
+            }
+        }
+
+        internal unsafe override bool IsDisposed
+        {
+            get
+            {
+                return (nativePathspec == null);
+            }
+        }
+
+        internal unsafe override void Dispose(bool disposing)
+        {
+            if (nativePathspec != null)
+            {
+                libgit2.git_pathspec_free(nativePathspec);
+                nativePathspec = null;
+            }
+        }
+    }
+}

--- a/Dogged/Tree.cs
+++ b/Dogged/Tree.cs
@@ -121,5 +121,30 @@ namespace Dogged
         {
             return GetEnumerator();
         }
+
+        /// <summary>
+        /// Match a pathspec against files in a tree.
+        /// </summary>
+        /// <param name="pathSpec">The pathspec to match.</param>
+        /// <returns>True if any matches found, otherwise, false</returns>
+        public unsafe bool IsMatch(PathSpec pathSpec)
+        {
+            return IsMatch(pathSpec, PathSpecFlags.Default);
+        }
+
+        /// <summary>
+        /// Match a pathspec against files in a tree.
+        /// </summary>
+        /// <param name="pathSpec">The pathspec to match.</param>
+        /// <param name="flags">Options to control the match.</param>
+        /// <returns>True if any matches found, otherwise, false</returns>
+        public unsafe bool IsMatch(PathSpec pathSpec, PathSpecFlags flags)
+        {
+            flags |= PathSpecFlags.NoMatchError;
+
+            git_pathspec_match_list* matchList = null;
+            int ret = Ensure.NativeCall(() => libgit2.git_pathspec_match_tree(ref matchList, NativeTree, (git_pathspec_flag_t)flags, pathSpec.NativePathspec), this);
+            return ret == 0;
+        }
     }
 }


### PR DESCRIPTION
Implements a simple pathspec matching on trees, without returning the list of matches.

A custom marshaler for `git_strarray` has also been added to assist the marshaling.